### PR TITLE
feat: Add CI/CD workflows for automated builds and deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,109 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main, master]
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}
+      version: ${{ steps.version.outputs.version }}
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # Tagged release
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            # Main/master branch - use short SHA
+            VERSION="sha-${GITHUB_SHA::7}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64,linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create release (on tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          
+  trigger-deployment:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    
+    steps:
+      - name: Trigger infrastructure deployment
+        run: |
+          # Extract just the sha-XXX tag
+          IMAGE_TAG="sha-${GITHUB_SHA::7}"
+          
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.INFRA_DEPLOY_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/statpan/statpan-infra/dispatches \
+            -d "{
+              \"event_type\": \"deploy-assemblymcp\",
+              \"client_payload\": {
+                \"image_tag\": \"$IMAGE_TAG\",
+                \"repository\": \"${{ github.repository }}\",
+                \"sha\": \"${{ github.sha }}\",
+                \"ref\": \"${{ github.ref }}\",
+                \"actor\": \"${{ github.actor }}\"
+              }
+            }"
+          
+          echo "Triggered deployment with image tag: $IMAGE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get current version
+        id: current_version
+        run: |
+          # Get latest tag or default to 0.0.0
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "current_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Current version: $LATEST_TAG"
+
+      - name: Bump version
+        id: bump_version
+        run: |
+          CURRENT="${{ steps.current_version.outputs.current_tag }}"
+          CURRENT=${CURRENT#v}  # Remove 'v' prefix
+          
+          IFS='.' read -r -a VERSION_PARTS <<< "$CURRENT"
+          MAJOR="${VERSION_PARTS[0]:-0}"
+          MINOR="${VERSION_PARTS[1]:-0}"
+          PATCH="${VERSION_PARTS[2]:-0}"
+          
+          case "${{ inputs.version_bump }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      - name: Update version in pyproject.toml
+        run: |
+          NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
+          NEW_VERSION=${NEW_VERSION#v}  # Remove 'v' prefix for pyproject.toml
+          sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" pyproject.toml
+          
+      - name: Commit version bump
+        run: |
+          NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
+          git add pyproject.toml
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push
+
+      - name: Create and push tag
+        run: |
+          NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
+          git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+          git push origin "$NEW_VERSION"
+          
+      - name: Summary
+        run: |
+          echo "### Release Created! 🎉" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ steps.bump_version.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Type**: ${{ inputs.version_bump }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The build and deployment workflow will trigger automatically." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 🚀 Changes

### New Workflows

#### 1. **deploy.yml** - Automated Build & Deploy
- **Triggers**: Push to main/master branch or tag creation
- **Features**:
  - Multi-architecture Docker builds (ARM64 + AMD64)
  - Push to GitHub Container Registry (ghcr.io)
  - Semantic versioning support (tags: v1.2.3)
  - SHA-based tags for main branch (sha-abc1234)
  - GitHub Buildx caching for faster builds
  - Automatic GitHub Release creation on tags
  - Triggers statpan-infra deployment via repository_dispatch

#### 2. **release.yml** - Semantic Version Management
- **Trigger**: Manual workflow dispatch
- **Features**:
  - Bump version (patch/minor/major)
  - Update pyproject.toml automatically
  - Create and push git tags
  - Triggers deploy.yml automatically

## 🔧 Required Setup

### In AssemblyMCP Repository
Nothing! Uses default GITHUB_TOKEN.

### In statpan-infra Repository
Add this secret:
```
INFRA_DEPLOY_TOKEN: GitHub PAT with repo scope (for receiving repository_dispatch)
```

## 📋 Usage

### Automatic Deployment (on merge to main)
1. Merge PR → triggers deploy.yml
2. Builds image → pushes to ghcr.io/statpan/assemblymcp:sha-XXX
3. Triggers statpan-infra deployment

### Manual Release
1. Go to Actions → Run workflow: Release
2. Choose version bump type (patch/minor/major)
3. Creates tag → triggers deploy.yml
4. Deploys versioned image

## ✅ Testing

- [x] Workflow syntax validated
- [ ] Will test on merge

## 🔗 Related
- Part of OKE deployment infrastructure setup
- Integrates with statpan-infra repository