### PR TITLE
fix(server): resolve Event Loop Closed error by lazy initialization

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "assemblymcp"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "assembly-api-client" },


### PR DESCRIPTION
## Issue
The server was crashing with `RuntimeError: Event loop is closed` on Cloud Run (and other async environments).
This was caused by `asyncio.run(ensure_master_list(client))` running at the module level. This created and closed an event loop, but the `AssemblyAPIClient` (via `httpx`) bound its connection pool to that closed loop. Subsequent requests tried to use the closed pool.

## Fix
- Removed the global `asyncio.run` call.
- Introduced `InitializationMiddleware` to handle one-time setup of the master list *lazily* on the first request. This ensures initialization happens within the running server's event loop.
- Reordered `server.py` initialization to ensure `client` is ready before middleware registration.

## Verification
- `scripts/test_mcp_integration.py` runs successfully without crashes.
- Unit tests pass.