### PR TITLE
fix: sync package version metadata

### DIFF
--- a/assemblymcp/__init__.py
+++ b/assemblymcp/__init__.py
@@ -1,3 +1,3 @@
 """AssemblyMCP - MCP Server for Korean National Assembly Open API"""
 
-__version__ = "0.1.0"
+__version__ = "0.6.3"

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "assemblymcp"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "assembly-api-client" },


### PR DESCRIPTION
## Summary
- sync `assemblymcp.__version__` with the released project version `0.6.3`
- refresh editable package version in `uv.lock`

## Validation
- `uv run pytest -q` -> `67 passed`
- real API smoke check -> bills, members, meetings, committees all returned data
