### PR TITLE
refactor: derive package version from metadata

### DIFF
--- a/assemblymcp/__init__.py
+++ b/assemblymcp/__init__.py
@@ -1,3 +1,17 @@
 """AssemblyMCP - MCP Server for Korean National Assembly Open API"""
 
-__version__ = "0.6.4"
+import warnings
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _load_package_version() -> str:
+    try:
+        # Local dev environments can retain stale dist-info after editable reinstalls.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return version("assemblymcp")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+__version__ = _load_package_version()

--- a/assemblymcp/__init__.py
+++ b/assemblymcp/__init__.py
@@ -1,3 +1,3 @@
 """AssemblyMCP - MCP Server for Korean National Assembly Open API"""
 
-__version__ = "0.1.0"
+__version__ = "0.6.4"

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -1,0 +1,6 @@
+import assemblymcp
+
+
+def test_package_version_matches_metadata():
+    assert assemblymcp.__version__ == assemblymcp._load_package_version()
+    assert assemblymcp.__version__ != "0.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "assemblymcp"
-version = "0.6.2"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "assembly-api-client" },


### PR DESCRIPTION
## Summary
- remove the hard-coded `assemblymcp.__version__` constant
- derive package version from installed metadata instead
- add a regression test to keep runtime version and package metadata aligned

## Why
- automatic version bumps were updating `pyproject.toml` without keeping `assemblymcp.__version__` in sync
- this makes runtime version reporting depend on a single source of truth

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` -> `68 passed`
